### PR TITLE
make image optimizer compatible with apple silicon

### DIFF
--- a/src/ImageOptimizer.php
+++ b/src/ImageOptimizer.php
@@ -277,7 +277,9 @@ class ImageOptimizer
         $binary = basename($name);
 
         return $finder->find($binary, $included, [
-
+            
+            '/opt/homebrew/bin',
+            '/opt/homebrew/sbin',
             '/usr/local',
             '/usr/local/bin',
             '/usr/bin',


### PR DESCRIPTION
Since the release of Homebrew for Apple Silicon, all bins are installed to different paths.